### PR TITLE
fix: if wkt is polygon, normalize it as geojson array

### DIFF
--- a/src/dataSource.js
+++ b/src/dataSource.js
@@ -247,7 +247,7 @@ class FileToDB {
 
   multiPolygon2Polygons = (wkt) => {
     const geoJson = geoParse(wkt);
-    if (geoJson["type"] === "Polygon") return geoJson;
+    if (geoJson["type"] === "Polygon") return [geoJson];
 
     const polygonsArray = geoJson["coordinates"].map((polygonCoordinates) => {
       return { type: "Polygon", coordinates: polygonCoordinates };


### PR DESCRIPTION
if user provide multipolygon as wkt, the script will parse it to array of polygon for each row,

if it polygon provided it should only parse to geojson and return array of single object